### PR TITLE
(draft) feat: Forward server-side output when pushing

### DIFF
--- a/gscp/push_pull.py
+++ b/gscp/push_pull.py
@@ -9,6 +9,13 @@ _NO_UPSTREAM = "no upstream branch"
 _REMOTE_WORK = "remote contains work"
 
 
+def _extract_remote_output(text: str) -> str:
+    lines = [
+        line for line in text.splitlines(keepends=True) if line.startswith("remote:")
+    ]
+    return "".join(lines)
+
+
 def _push_upstream(branch: str, remote: str = "origin") -> None:
     """
     Push by setting the upstream branch
@@ -19,7 +26,11 @@ def _push_upstream(branch: str, remote: str = "origin") -> None:
     """
 
     command = ["git", "push", "--set-upstream", remote, branch]
-    subprocess.run(command, capture_output=True, check=True, timeout=10)
+    result = subprocess.run(
+        command, capture_output=True, text=True, check=True, timeout=10
+    )
+    remote_output = _extract_remote_output(result.stderr)
+    print(remote_output, end="")
 
 
 def _get_remote_name() -> str:


### PR DESCRIPTION
A sample output is worth a thousand words:
```
$ gscp
[test4 baad964] test4
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 hello
It seems there is no upstream branch. Do you want to push to origin/test4 or another remote? [y/n/o] (y): y
remote: 
remote: Create a pull request for 'test4' on GitHub by visiting:        
remote:      https://github.com/selimb/gscp/pull/new/test4        
remote: 
```

This forwarding is currently always enabled, but let me know if you'd like to have it configurable -- personally I'd prefer an env var that I can set globally instead of a command-line argument. 